### PR TITLE
default_config explicitly unset dnsmasq

### DIFF
--- a/configs/default_config
+++ b/configs/default_config
@@ -32,6 +32,7 @@ CONFIG_PACKAGE_babeld=y
 CONFIG_PACKAGE_batctl=y
 CONFIG_PACKAGE_block-mount=y
 CONFIG_PACKAGE_bwm-ng=y
+# CONFIG_PACKAGE_dnsmasq is not set
 CONFIG_PACKAGE_dnsmasq-dhcpv6=y
 CONFIG_PACKAGE_ebtables=y
 CONFIG_PACKAGE_ethtool=y


### PR DESCRIPTION
When compiling with OpenWrt 18.06, the current `configs/default_config` works perfectly well.
But I tried to use the same configuration for compiling on OpenWrt **trunk** and it fails due to `dnsmasq` being selected by default.

I didn't manage to get why in trunk `dnsmasq` gets selected by default while this does not happen in 18.06.
Anyway explicitly deselecting it in `configs/default_config` solves for trunk and does not cause any harm on 18.06.
