### PR TITLE
Add full-iw package

### DIFF
--- a/package/network/utils/iw/Makefile
+++ b/package/network/utils/iw/Makefile
@@ -15,6 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/iw
 PKG_HASH:=f01671c0074bfdec082a884057edba1b9efd35c89eda554638496f03b769ad89
 
+PKG_BUILD_DIR:=$(BUILD_DIR)/iw-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=GPL-2.0
 
@@ -26,6 +27,14 @@ define Package/iw
   TITLE:=cfg80211 interface configuration utility
   URL:=http://wireless.kernel.org/en/users/Documentation/iw
   DEPENDS:= +libnl-tiny
+  VARIANT:=tiny
+endef
+
+define Package/iw-full
+  $(Package/iw)
+  TITLE += (full version)
+  VARIANT:=full
+  PROVIDES:=iw
 endef
 
 define Build/Configure
@@ -41,6 +50,11 @@ TARGET_CPPFLAGS:= \
 	-D_GNU_SOURCE \
 	-flto
 
+ifeq ($(BUILD_VARIANT),full)
+  TARGET_CPPFLAGS += -DIW_FULL
+  MAKE_FLAGS += IW_FULL=1
+endif
+
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) -ffunction-sections -fdata-sections" \
 	LDFLAGS="$(TARGET_LDFLAGS) -Wl,--gc-sections -flto" \
@@ -54,4 +68,7 @@ define Package/iw/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/iw $(1)/usr/sbin/
 endef
 
+Package/iw-full/install=$(Package/iw/install)
+
 $(eval $(call BuildPackage,iw))
+$(eval $(call BuildPackage,iw-full))

--- a/package/network/utils/iw/Makefile
+++ b/package/network/utils/iw/Makefile
@@ -38,11 +38,12 @@ TARGET_CPPFLAGS:= \
 	-I$(STAGING_DIR)/usr/include/libnl-tiny \
 	$(TARGET_CPPFLAGS) \
 	-DCONFIG_LIBNL20 \
-	-D_GNU_SOURCE
+	-D_GNU_SOURCE \
+	-flto
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) -ffunction-sections -fdata-sections" \
-	LDFLAGS="$(TARGET_LDFLAGS) -Wl,--gc-sections" \
+	LDFLAGS="$(TARGET_LDFLAGS) -Wl,--gc-sections -flto" \
 	NL1FOUND="" NL2FOUND=Y \
 	NLLIBNAME="libnl-tiny" \
 	LIBS="-lm -lnl-tiny" \

--- a/package/network/utils/iw/patches/200-reduce_size.patch
+++ b/package/network/utils/iw/patches/200-reduce_size.patch
@@ -270,7 +270,7 @@
  
  OBJS += $(OBJS-y) $(OBJS-Y)
  
-+OBJS_FULL = ocb offch cqm wowlan coalesce roc p2p ap
++OBJS_FULL = ocb offch cqm wowlan coalesce roc p2p ap mgmt vendor
 +ifdef IW_FULL
 +  CFLAGS += -DIW_FULL
 +else
@@ -308,3 +308,48 @@
  
  static int handle_station_dump(struct nl80211_state *state,
  			       struct nl_msg *msg,
+--- a/interface.c
++++ b/interface.c
+@@ -615,9 +615,11 @@ static int handle_interface_wds_peer(str
+  nla_put_failure:
+ 	return -ENOBUFS;
+ }
++#ifdef IW_FULL
+ COMMAND(set, peer, "<MAC address>",
+ 	NL80211_CMD_SET_WDS_PEER, 0, CIB_NETDEV, handle_interface_wds_peer,
+ 	"Set interface WDS peer.");
++#endif
+ 
+ static int set_mcast_rate(struct nl80211_state *state,
+ 			  struct nl_msg *msg,
+@@ -707,6 +709,7 @@ static int handle_chan(struct nl80211_st
+ 	return handle_chanfreq(state, msg, true, argc, argv, id);
+ }
+ 
++#ifdef IW_FULL
+ SECTION(switch);
+ COMMAND(switch, freq,
+ 	"<freq> [NOHT|HT20|HT40+|HT40-|5MHz|10MHz|80MHz] [beacons <count>] [block-tx]\n"
+@@ -715,3 +718,4 @@ COMMAND(switch, freq,
+ 	"Switch the operating channel by sending a channel switch announcement (CSA).");
+ COMMAND(switch, channel, "<channel> [NOHT|HT20|HT40+|HT40-|5MHz|10MHz|80MHz] [beacons <count>] [block-tx]",
+ 	NL80211_CMD_CHANNEL_SWITCH, 0, CIB_NETDEV, handle_chan, NULL);
++#endif
+--- a/phy.c
++++ b/phy.c
+@@ -359,6 +359,7 @@ static int handle_cac(struct nl80211_sta
+ 
+ 	return 0;
+ }
++#ifdef IW_FULL
+ TOPLEVEL(cac, "channel <channel> [NOHT|HT20|HT40+|HT40-|5MHz|10MHz|80MHz]\n"
+ 	      "freq <freq> [NOHT|HT20|HT40+|HT40-|5MHz|10MHz|80MHz]\n"
+ 	      "freq <control freq> [5|10|20|40|80|80+80|160] [<center1_freq> [<center2_freq>]]",
+@@ -370,6 +371,7 @@ COMMAND(cac, trigger,
+ 	NL80211_CMD_RADAR_DETECT, 0, CIB_NETDEV, handle_cac_trigger,
+ 	"Start or trigger a channel availability check (CAC) looking to look for\n"
+ 	"radars on the given channel.");
++#endif
+ 
+ static int handle_fragmentation(struct nl80211_state *state,
+ 				struct nl_msg *msg,

--- a/package/network/utils/iw/patches/200-reduce_size.patch
+++ b/package/network/utils/iw/patches/200-reduce_size.patch
@@ -274,7 +274,7 @@
 +ifdef IW_FULL
 +  CFLAGS += -DIW_FULL
 +else
-+  OBJS:=$(filter-out $(patsubst %,%.o,$(OBJS_DISABLED)),$(OBJS))
++  OBJS:=$(filter-out $(patsubst %,%.o,$(OBJS_FULL)),$(OBJS))
 +endif
  ALL = iw
  

--- a/package/network/utils/iw/patches/200-reduce_size.patch
+++ b/package/network/utils/iw/patches/200-reduce_size.patch
@@ -4,7 +4,7 @@
  	}
  
  	switch (gnlh->cmd) {
-+#if 0
++#ifdef IW_FULL
  	case NL80211_CMD_NEW_WIPHY:
  		printf("renamed to %s\n", nla_get_string(tb[NL80211_ATTR_WIPHY_NAME]));
  		break;
@@ -20,7 +20,7 @@
  		mac_addr_n2a(macbuf, nla_data(tb[NL80211_ATTR_MAC]));
  		printf("del station %s\n", macbuf);
  		break;
-+#if 0
++#ifdef IW_FULL
  	case NL80211_CMD_JOIN_IBSS:
  		mac_addr_n2a(macbuf, nla_data(tb[NL80211_ATTR_MAC]));
  		printf("IBSS %s joined\n", macbuf);
@@ -42,7 +42,7 @@
  				}
  			}
  
-+#if 0
++#ifdef IW_FULL
  			if (tb_band[NL80211_BAND_ATTR_RATES]) {
  			printf("\t\tBitrates (non-HT):\n");
  			nla_for_each_nested(nl_rate, tb_band[NL80211_BAND_ATTR_RATES], rem_rate) {
@@ -58,7 +58,7 @@
  		printf("\tCoverage class: %d (up to %dm)\n", coverage, 450 * coverage);
  	}
  
-+#if 0
++#ifdef IW_FULL
  	if (tb_msg[NL80211_ATTR_CIPHER_SUITES]) {
  		int num = nla_len(tb_msg[NL80211_ATTR_CIPHER_SUITES]) / sizeof(__u32);
  		int i;
@@ -74,7 +74,7 @@
  			printf("\t\t * %s\n", iftype_name(nla_type(nl_mode)));
  	}
  
-+#if 0
++#ifdef IW_FULL
  	if (tb_msg[NL80211_ATTR_SOFTWARE_IFTYPES]) {
  		printf("\tsoftware interface modes (can always be added):\n");
  		nla_for_each_nested(nl_mode, tb_msg[NL80211_ATTR_SOFTWARE_IFTYPES], rem_mode)
@@ -88,7 +88,7 @@
  			printf("\tinterface combinations are not supported\n");
  	}
  
-+#if 0
++#ifdef IW_FULL
  	if (tb_msg[NL80211_ATTR_SUPPORTED_COMMANDS]) {
  		printf("\tSupported commands:\n");
  		nla_for_each_nested(nl_cmd, tb_msg[NL80211_ATTR_SUPPORTED_COMMANDS], rem_cmd)
@@ -104,7 +104,7 @@
  		}
  	}
  
-+#if 0
++#ifdef IW_FULL
  	if (tb_msg[NL80211_ATTR_FEATURE_FLAGS]) {
  		unsigned int features = nla_get_u32(tb_msg[NL80211_ATTR_FEATURE_FLAGS]);
  
@@ -120,7 +120,7 @@
  	 "List all wireless devices and their capabilities.");
  TOPLEVEL(phy, NULL, NL80211_CMD_GET_WIPHY, NLM_F_DUMP, CIB_NONE, handle_info, NULL);
  
-+#if 0
++#ifdef IW_FULL
  static int handle_commands(struct nl80211_state *state, struct nl_msg *msg,
  			   int argc, char **argv, enum id_input id)
  {
@@ -153,7 +153,7 @@
 +	[114] = { "MESH ID", print_ssid, 0, 32, BIT(PRINT_SCAN) | BIT(PRINT_LINK), },
 +	[191] = { "VHT capabilities", print_vht_capa, 12, 255, BIT(PRINT_SCAN), },
 +	[192] = { "VHT operation", print_vht_oper, 5, 255, BIT(PRINT_SCAN), },
-+#if 0
++#ifdef IW_FULL
  	[1] = { "Supported rates", print_supprates, 0, 255, BIT(PRINT_SCAN), },
  	[3] = { "DS Parameter set", print_ds, 1, 1, BIT(PRINT_SCAN), },
  	[5] = { "TIM", print_tim, 4, 255, BIT(PRINT_SCAN), },
@@ -184,7 +184,7 @@
  		    ieprinters[ie[0]].flags & BIT(ptype)) {
  			print_ie(&ieprinters[ie[0]],
  				 ie[0], ie[1], ie + 2, &ie_buffer);
-+#if 0
++#ifdef IW_FULL
  		} else if (ie[0] == 221 /* vendor */) {
  			print_vendor(ie[1], ie + 2, unknown, ptype);
  		} else if (unknown) {
@@ -200,7 +200,7 @@
  		printf(" ESS");
  	if (capa & WLAN_CAPABILITY_IBSS)
  		printf(" IBSS");
-+#if 0
++#ifdef IW_FULL
  	if (capa & WLAN_CAPABILITY_CF_POLLABLE)
  		printf(" CfPollable");
  	if (capa & WLAN_CAPABILITY_CF_POLL_REQUEST)
@@ -216,7 +216,7 @@
  	if (bss[NL80211_BSS_FREQUENCY]) {
  		int freq = nla_get_u32(bss[NL80211_BSS_FREQUENCY]);
  		printf("\tfreq: %d\n", freq);
-+#if 0
++#ifdef IW_FULL
  		if (freq > 45000)
  			is_dmg = true;
 +#endif
@@ -227,7 +227,7 @@
  	return 0;
  }
  
-+#if 0
++#ifdef IW_FULL
  COMMAND(scan, sched_start,
  	SCHED_SCAN_OPTIONS,
  	NL80211_CMD_START_SCHED_SCAN, 0, CIB_NETDEV, handle_start_sched_scan,
@@ -242,7 +242,7 @@
  
  static char cmdbuf[100];
  
-+#if 0
++#ifdef IW_FULL
  const char *command_name(enum nl80211_commands cmd)
  {
  	if (cmd <= NL80211_CMD_MAX && commands[cmd])
@@ -254,22 +254,28 @@
  
  int ieee80211_channel_to_frequency(int chan, enum nl80211_band band)
  {
-@@ -426,6 +428,7 @@ int parse_keys(struct nl_msg *msg, char
+@@ -426,6 +428,9 @@ int parse_keys(struct nl_msg *msg, char
  	char keybuf[13];
  	int pos = 0;
  
++#ifndef IW_FULL
 +	return 1;
++#endif
  	if (!argc)
  		return 1;
  
 --- a/Makefile
 +++ b/Makefile
-@@ -25,6 +25,8 @@ OBJS-$(HWSIM) += hwsim.o
+@@ -25,6 +25,12 @@ OBJS-$(HWSIM) += hwsim.o
  
  OBJS += $(OBJS-y) $(OBJS-Y)
  
-+OBJS_DISABLED = ocb offch cqm wowlan coalesce roc p2p ap
-+OBJS:=$(filter-out $(patsubst %,%.o,$(OBJS_DISABLED)),$(OBJS))
++OBJS_FULL = ocb offch cqm wowlan coalesce roc p2p ap
++ifdef IW_FULL
++  CFLAGS += -DIW_FULL
++else
++  OBJS:=$(filter-out $(patsubst %,%.o,$(OBJS_DISABLED)),$(OBJS))
++endif
  ALL = iw
  
  ifeq ($(NO_PKG_CONFIG),)
@@ -279,7 +285,7 @@
   nla_put_failure:
  	return -ENOBUFS;
  }
-+#if 0
++#ifdef IW_FULL
  COMMAND_ALIAS(station, set, "<MAC address> plink_action <open|block>",
  	NL80211_CMD_SET_STATION, 0, CIB_NETDEV, handle_station_set_plink,
  	"Set mesh peer link action for this station (peer).",
@@ -292,7 +298,7 @@
  nla_put_failure:
  	return -ENOBUFS;
  }
-+#if 0
++#ifdef IW_FULL
  COMMAND_ALIAS(station, set, "<MAC address> mesh_power_mode "
  	"<active|light|deep>", NL80211_CMD_SET_STATION, 0, CIB_NETDEV,
  	handle_station_set_mesh_power_mode,


### PR DESCRIPTION
This pull request incorporates the necessary changes to make available a version of iw full, without clipped code. The idea of having iw-full is to be able to access all the information of the beacons.
See more at https://github.com/cl4u2/ieswescan

The image generated is approximately 100kb larger, but the features we are testing are worth it.

Tested on tp-links 3600, not LibreRouters