### PR TITLE
selects the shared-state-nodes_and_links package

### DIFF
--- a/configs/default_config
+++ b/configs/default_config
@@ -119,6 +119,7 @@ CONFIG_PACKAGE_shared-state-dnsmasq_hosts=y
 CONFIG_PACKAGE_shared-state-dnsmasq_leases=y
 CONFIG_PACKAGE_shared-state-persist=y
 CONFIG_PACKAGE_shared-state-pirania=y
+CONFIG_PACKAGE_shared-state-nodes_and_links=y
 CONFIG_PACKAGE_sprunge=y
 CONFIG_PACKAGE_tcpdump-mini=y
 CONFIG_PACKAGE_terminfo=y


### PR DESCRIPTION
this is a required package to be able to see the community map in the lime-app.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
