### PR TITLE
add librerouter-hw package with an initial tool to validate hardware

### DIFF
--- a/package/system/librerouter-hw/Makefile
+++ b/package/system/librerouter-hw/Makefile
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2019 Santiago Piccinini <spiccinini@altermundi.net>
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=librerouter-hw
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Librerouter hardware tools
+endef
+
+define Package/$(PKG_NAME)/description
+	Tools for the librerouter HW support.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/system/librerouter-hw/files/etc/uci-defaults/99-run-librerouter-hw-check
+++ b/package/system/librerouter-hw/files/etc/uci-defaults/99-run-librerouter-hw-check
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# we wait until the LR is configured, up and stable
+(sleep 200 && librerouter-hw-check )&
+
+exit 0

--- a/package/system/librerouter-hw/files/usr/sbin/librerouter-hw-check
+++ b/package/system/librerouter-hw/files/usr/sbin/librerouter-hw-check
@@ -1,0 +1,57 @@
+#!/usr/bin/env lua
+
+local ERRORS = false
+
+local function run_command_get_output(cmd)
+    local handle = io.popen(cmd)
+    local output = handle:read('*all')
+    handle:close()
+    return output
+end
+
+local report_file = io.open('/root/librerouter-hw-check-report.txt', 'w')
+
+local function log(str)
+    print(str)
+    report_file:write(str..'\n')
+end
+
+log('* Checking radio interfaces:')
+local up_interfaces = run_command_get_output("iw dev | grep Interface | awk '{print $2}'")
+
+for _, iface_prefix in pairs({'wlan0', 'wlan1', 'wlan2'}) do
+    local up = string.find(up_interfaces, iface_prefix) ~= nil
+    if up then
+        log('\t' .. iface_prefix .. ' interface: OK')
+    else
+        log('\t' .. iface_prefix .. ' interface: BAD')
+        ERRORS = true
+    end
+end
+
+log('* Checking mac addresses:')
+local mac_addresses = run_command_get_output("cat /sys/class/net/*/address")
+
+local bad_mac_empty = string.find(mac_addresses, '02:03:04:05:06') ~= nil
+local bad_mac_atheros = string.find(mac_addresses, '00:03:7f:00:01') ~= nil
+
+local bad_mac = bad_mac_empty or bad_mac_atheros
+if bad_mac then
+    log('\tMAC address: BAD')
+    log(mac_addresses)
+    ERRORS = true
+else
+    log('\tMAC address: OK')
+end
+
+-- run safe-upgrade bootstraping. There is no problem if it is already bootstraped
+run_command_get_output("safe-upgrade bootstrap")
+
+
+if ERRORS then
+    log("ERROR: errors ocurred!")
+    os.exit(125)
+else
+    log("SUCCESS")
+    os.exit(0)
+end

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -1391,7 +1391,7 @@ TARGET_DEVICES += fritz450e
 
 define Device/librerouter-v1
   DEVICE_TITLE := LibreRouter v1
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage safe-upgrade om-watchdog
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage safe-upgrade om-watchdog librerouter-hw
   BOARDNAME := LIBREROUTERV1
   IMAGE_SIZE := 32384k
   KERNEL := kernel-bin | lzma | uImage lzma


### PR DESCRIPTION
The validation tool runs automatically at the first boot and stores the report at `/root/librerouter-hw-check-report.txt`. 
For now it only checks that all the three radios are up and that the MACs are good. More checks will be added in the future. I was thinking for example in a self check of the 5GHz radios setting them at the same channel and running some benchmark of signal quality without antennas connected.